### PR TITLE
Add script to start gatus

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ Dockerfile
 .git
 web/app
 *.db
+*.sh

--- a/start-gatus.sh
+++ b/start-gatus.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+make docker-build
+
+docker run --publish 127.0.0.1:8080:8080 \
+           --name gatus \
+           --volume `pwd`/gatus_configuration:/config:ro \
+           --detach \
+           twinproduction/gatus:latest


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [X] Commit message follows the Contribution Guidelines
- [ ] Tests ran locally and added/modified if needed
- [ ] Docs have been added/updated, if applicable
- [ ] If applicable - JIRA ticket ID was added

* **What kind of change does this PR introduce?** (Bug fix, feature, unit tests, docs update, ...)

This script builds the container and start gatus without exposing it to
the web, on port 8080, with the configuration directory
gatus_configuration bind mounted to /config in read-only mode. This
allows us to change the configuration without needing to restart the
Gatus container.


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Please describe what manual tests you ran, if applicable**


* **Other information**:
