### PR TITLE
start-gatus.sh: mount /data/ in container for db

### DIFF
--- a/start-gatus.sh
+++ b/start-gatus.sh
@@ -7,5 +7,6 @@ make docker-build
 docker run --publish 127.0.0.1:8080:8080 \
            --name gatus \
            --volume `pwd`/gatus_configuration:/config:ro \
+           --volume `pwd`/data/:/data/:rw \
            --detach \
            twinproduction/gatus:latest


### PR DESCRIPTION
We are using an sqlite database for the historical data and we want to persist it outside the container.

* **Please check if the PR fulfills these requirements**
- [X] Commit message follows the Contribution Guidelines
- [ ] Tests ran locally and added/modified if needed
- [ ] Docs have been added/updated, if applicable
- [ ] If applicable - JIRA ticket ID was added

* **What kind of change does this PR introduce?** (Bug fix, feature, unit tests, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Please describe what manual tests you ran, if applicable**


* **Other information**:
