### PR TITLE
Fix comparison of block heights

### DIFF
--- a/core/condition.go
+++ b/core/condition.go
@@ -399,7 +399,15 @@ func blockNum(result *Result, first, second string) bool {
 	}
 
 	result.AddError(fmt.Sprintf("rpc: %d, reference: %d", firstI, secondI))
-	return !(secondI-firstI > deltaThreshold)
+	return !(absInt(secondI-firstI) > deltaThreshold)
+}
+
+func absInt(number int64) int64 {
+	if number < 0 {
+		return -number
+	} else {
+		return number
+	}
 }
 
 // isEqual compares two strings.


### PR DESCRIPTION
Use an absolute comparison between our RPC node's block height and the reference value.

Note: `math.Abs()` is only for floats.

* **Please check if the PR fulfills these requirements**
- [X] Commit message follows the Contribution Guidelines
- [ ] Tests ran locally and added/modified if needed
- [ ] Docs have been added/updated, if applicable
- [ ] If applicable - JIRA ticket ID was added

* **What kind of change does this PR introduce?** (Bug fix, feature, unit tests, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Please describe what manual tests you ran, if applicable**


* **Other information**:
