### PR TITLE
Add custom url for custom alerts

### DIFF
--- a/alerting/alert/alert.go
+++ b/alerting/alert/alert.go
@@ -54,6 +54,12 @@ type Alert struct {
 	// some reason, the alert provider always returns errors when trying to send the resolved notification
 	// (SendOnResolved).
 	Triggered bool `yaml:"-"`
+
+	// CustomURL is an additional attribute for custom alerts. Gatus by default provides only one custom alert,
+	// but our requirement is to send multiple custom requests to different URLs.
+	// This field overrides the added URL in the custom alert declaration for this endpoint.
+	// Note that for other types of alerts, this field does not have any effect.
+	CustomURL string `yaml:"custom-url,omitempty"`
 }
 
 // ValidateAndSetDefaults validates the alert's configuration and sets the default value of fields that have one

--- a/alerting/provider/custom/custom.go
+++ b/alerting/provider/custom/custom.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 
@@ -103,7 +102,6 @@ func getCustomURLFromEndpoint(endpoint *core.Endpoint) string {
 }
 
 func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) error {
-	log.Printf("[config][Custom], USAOO")
 	request := provider.buildHTTPRequest(endpoint, alert, resolved)
 	response, err := client.GetHTTPClient(provider.ClientConfig).Do(request)
 	if err != nil {


### PR DESCRIPTION
### Description:

This PR introduces the CustomURL attribute to enhance the functionality of custom alerts in Gatus. The addition of this attribute allows for sending multiple custom requests to different URLs, as opposed to the default behavior which supports only one custom alert.

How to use it:

If you are having custom alerts in endpoint you can add custom url, and than the request would not be send in the url defined on customAlert declaration but the provided one

```
endpoints:
  - name: front-end
    group: core
    url: "https://twin.sh/health"
    interval: 3s
    conditions:
      - "[STATUS] != 200"
    alerts:
      - type: custom
        custom-url: "www.facebook.com"
```