### PR TITLE
feat: support monitoring WebSocket endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Monitoring a TCP endpoint](#monitoring-a-tcp-endpoint)
   - [Monitoring a UDP endpoint](#monitoring-a-udp-endpoint)
   - [Monitoring a SCTP endpoint](#monitoring-a-sctp-endpoint)
+  - [Monitoring a WebSocket endpoint](#monitoring-a-websocket-endpoint)
   - [Monitoring an endpoint using ICMP](#monitoring-an-endpoint-using-icmp)
   - [Monitoring an endpoint using DNS queries](#monitoring-an-endpoint-using-dns-queries)
   - [Monitoring an endpoint using STARTTLS](#monitoring-an-endpoint-using-starttls)
@@ -196,54 +197,55 @@ If you want to test it locally, see [Docker](#docker).
 ## Configuration
 | Parameter                                       | Description                                                                                                                                 | Default                    |
 |:------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------|
-| `debug`                                         | Whether to enable debug logs.                                                                                                               | `false`                    |
-| `metrics`                                       | Whether to expose metrics at /metrics.                                                                                                      | `false`                    |
-| `storage`                                       | [Storage configuration](#storage)                                                                                                           | `{}`                       |
-| `endpoints`                                     | List of endpoints to monitor.                                                                                                               | Required `[]`              |
-| `endpoints[].enabled`                           | Whether to monitor the endpoint.                                                                                                            | `true`                     |
-| `endpoints[].name`                              | Name of the endpoint. Can be anything.                                                                                                      | Required `""`              |
-| `endpoints[].group`                             | Group name. Used to group multiple endpoints together on the dashboard. <br />See [Endpoint groups](#endpoint-groups).                      | `""`                       |
-| `endpoints[].url`                               | URL to send the request to.                                                                                                                 | Required `""`              |
-| `endpoints[].method`                            | Request method.                                                                                                                             | `GET`                      |
-| `endpoints[].conditions`                        | Conditions used to determine the health of the endpoint. <br />See [Conditions](#conditions).                                               | `[]`                       |
-| `endpoints[].interval`                          | Duration to wait between every status check.                                                                                                | `60s`                      |
-| `endpoints[].graphql`                           | Whether to wrap the body in a query param (`{"query":"$body"}`).                                                                            | `false`                    |
-| `endpoints[].body`                              | Request body.                                                                                                                               | `""`                       |
-| `endpoints[].headers`                           | Request headers.                                                                                                                            | `{}`                       |
-| `endpoints[].dns`                               | Configuration for an endpoint of type DNS. <br />See [Monitoring an endpoint using DNS queries](#monitoring-an-endpoint-using-dns-queries). | `""`                       |
-| `endpoints[].dns.query-type`                    | Query type (e.g. MX)                                                                                                                        | `""`                       |
-| `endpoints[].dns.query-name`                    | Query name (e.g. example.com)                                                                                                               | `""`                       |
-| `endpoints[].alerts[].type`                     | Type of alert. <br />See [Alerting](#alerting) for all valid types.                                                                         | Required `""`              |
-| `endpoints[].alerts[].enabled`                  | Whether to enable the alert.                                                                                                                | `true`                     |
-| `endpoints[].alerts[].failure-threshold`        | Number of failures in a row needed before triggering the alert.                                                                             | `3`                        |
-| `endpoints[].alerts[].success-threshold`        | Number of successes in a row before an ongoing incident is marked as resolved.                                                              | `2`                        |
-| `endpoints[].alerts[].send-on-resolved`         | Whether to send a notification once a triggered alert is marked as resolved.                                                                | `false`                    |
-| `endpoints[].alerts[].description`              | Description of the alert. Will be included in the alert sent.                                                                               | `""`                       |
-| `endpoints[].client`                            | [Client configuration](#client-configuration).                                                                                              | `{}`                       |
-| `endpoints[].ui`                                | UI configuration at the endpoint level.                                                                                                     | `{}`                       |
-| `endpoints[].ui.hide-hostname`                  | Whether to hide the hostname in the result.                                                                                                 | `false`                    |
-| `endpoints[].ui.hide-url`                       | Whether to ensure the URL is not displayed in the results. Useful if the URL contains a token.                                              | `false`                    |
-| `endpoints[].ui.dont-resolve-failed-conditions` | Whether to resolve failed conditions for the UI.                                                                                            | `false`                    |
-| `endpoints[].ui.badge.reponse-time`             | List of response time thresholds. Each time a threshold is reached, the badge has a different color.                                        | `[50, 200, 300, 500, 750]` |
-| `alerting`                                      | [Alerting configuration](#alerting).                                                                                                        | `{}`                       |
-| `security`                                      | [Security configuration](#security).                                                                                                        | `{}`                       |
-| `disable-monitoring-lock`                       | Whether to [disable the monitoring lock](#disable-monitoring-lock).                                                                         | `false`                    |
-| `skip-invalid-config-update`                    | Whether to ignore invalid configuration update. <br />See [Reloading configuration on the fly](#reloading-configuration-on-the-fly).        | `false`                    |
-| `web`                                           | Web configuration.                                                                                                                          | `{}`                       |
-| `web.address`                                   | Address to listen on.                                                                                                                       | `0.0.0.0`                  |
-| `web.port`                                      | Port to listen on.                                                                                                                          | `8080`                     |
-| `web.tls.certificate-file`                      | Optional public certificate file for TLS in PEM format.                                                                                     | ``                         |
-| `web.tls.private-key-file`                      | Optional private key file for TLS in PEM format.                                                                                            | ``                         |
-| `ui`                                            | UI configuration.                                                                                                                           | `{}`                       |
-| `ui.title`                                      | [Title of the document](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title).                                                   | `Health Dashboard ǀ Gatus` |
-| `ui.description`                                | Meta description for the page.                                                                                                              | `Gatus is an advanced...`. |
-| `ui.header`                                     | Header at the top of the dashboard.                                                                                                         | `Health Status`            |
-| `ui.logo`                                       | URL to the logo to display.                                                                                                                 | `""`                       |
-| `ui.link`                                       | Link to open when the logo is clicked.                                                                                                      | `""`                       |
-| `ui.buttons`                                    | List of buttons to display below the header.                                                                                                | `[]`                       |
-| `ui.buttons[].name`                             | Text to display on the button.                                                                                                              | Required `""`              |
-| `ui.buttons[].link`                             | Link to open when the button is clicked.                                                                                                    | Required `""`              |
-| `maintenance`                                   | [Maintenance configuration](#maintenance).                                                                                                  | `{}`                       |
+| `debug`                                         | Whether to enable debug logs.                                                                                                                   | `false`                    |
+| `metrics`                                       | Whether to expose metrics at /metrics.                                                                                                          | `false`                    |
+| `storage`                                       | [Storage configuration](#storage)                                                                                                               | `{}`                       |
+| `endpoints`                                     | List of endpoints to monitor.                                                                                                                   | Required `[]`              |
+| `endpoints[].enabled`                           | Whether to monitor the endpoint.                                                                                                                | `true`                     |
+| `endpoints[].name`                              | Name of the endpoint. Can be anything.                                                                                                          | Required `""`              |
+| `endpoints[].group`                             | Group name. Used to group multiple endpoints together on the dashboard. <br />See [Endpoint groups](#endpoint-groups).                          | `""`                       |
+| `endpoints[].url`                               | URL to send the request to.                                                                                                                     | Required `""`              |
+| `endpoints[].method`                            | Request method.                                                                                                                                 | `GET`                      |
+| `endpoints[].conditions`                        | Conditions used to determine the health of the endpoint. <br />See [Conditions](#conditions).                                                   | `[]`                       |
+| `endpoints[].interval`                          | Duration to wait between every status check.                                                                                                    | `60s`                      |
+| `endpoints[].graphql`                           | Whether to wrap the body in a query param (`{"query":"$body"}`).                                                                                | `false`                    |
+| `endpoints[].body`                              | Request body.                                                                                                                                   | `""`                       |
+| `endpoints[].headers`                           | Request headers.                                                                                                                                | `{}`                       |
+| `endpoints[].dns`                               | Configuration for an endpoint of type DNS. <br />See [Monitoring an endpoint using DNS queries](#monitoring-an-endpoint-using-dns-queries).     | `""`                       |
+| `endpoints[].dns.query-type`                    | Query type (e.g. MX)                                                                                                                            | `""`                       |
+| `endpoints[].dns.query-name`                    | Query name (e.g. example.com)                                                                                                                   | `""`                       |
+| `endpoints[].jsonrpc`                           | Whether to wrap the request `body` in a JSON RPC 2.0 method call.<br />See [Monitoring a WebSocket endpoint](#monitoring-a-websocket-endpoint). | `false`                    |
+| `endpoints[].alerts[].type`                     | Type of alert. <br />See [Alerting](#alerting) for all valid types.                                                                             | Required `""`              |
+| `endpoints[].alerts[].enabled`                  | Whether to enable the alert.                                                                                                                    | `true`                     |
+| `endpoints[].alerts[].failure-threshold`        | Number of failures in a row needed before triggering the alert.                                                                                 | `3`                        |
+| `endpoints[].alerts[].success-threshold`        | Number of successes in a row before an ongoing incident is marked as resolved.                                                                  | `2`                        |
+| `endpoints[].alerts[].send-on-resolved`         | Whether to send a notification once a triggered alert is marked as resolved.                                                                    | `false`                    |
+| `endpoints[].alerts[].description`              | Description of the alert. Will be included in the alert sent.                                                                                   | `""`                       |
+| `endpoints[].client`                            | [Client configuration](#client-configuration).                                                                                                  | `{}`                       |
+| `endpoints[].ui`                                | UI configuration at the endpoint level.                                                                                                         | `{}`                       |
+| `endpoints[].ui.hide-hostname`                  | Whether to hide the hostname in the result.                                                                                                     | `false`                    |
+| `endpoints[].ui.hide-url`                       | Whether to ensure the URL is not displayed in the results. Useful if the URL contains a token.                                                  | `false`                    |
+| `endpoints[].ui.dont-resolve-failed-conditions` | Whether to resolve failed conditions for the UI.                                                                                                | `false`                    |
+| `endpoints[].ui.badge.reponse-time`             | List of response time thresholds. Each time a threshold is reached, the badge has a different color.                                            | `[50, 200, 300, 500, 750]` |
+| `alerting`                                      | [Alerting configuration](#alerting).                                                                                                            | `{}`                       |
+| `security`                                      | [Security configuration](#security).                                                                                                            | `{}`                       |
+| `disable-monitoring-lock`                       | Whether to [disable the monitoring lock](#disable-monitoring-lock).                                                                             | `false`                    |
+| `skip-invalid-config-update`                    | Whether to ignore invalid configuration update. <br />See [Reloading configuration on the fly](#reloading-configuration-on-the-fly).            | `false`                    |
+| `web`                                           | Web configuration.                                                                                                                              | `{}`                       |
+| `web.address`                                   | Address to listen on.                                                                                                                           | `0.0.0.0`                  |
+| `web.port`                                      | Port to listen on.                                                                                                                              | `8080`                     |
+| `web.tls.certificate-file`                      | Optional public certificate file for TLS in PEM format.                                                                                         | ``                         |
+| `web.tls.private-key-file`                      | Optional private key file for TLS in PEM format.                                                                                                | ``                         |
+| `ui`                                            | UI configuration.                                                                                                                               | `{}`                       |
+| `ui.title`                                      | [Title of the document](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title).                                                       | `Health Dashboard ǀ Gatus` |
+| `ui.description`                                | Meta description for the page.                                                                                                                  | `Gatus is an advanced...`. |
+| `ui.header`                                     | Header at the top of the dashboard.                                                                                                             | `Health Status`            |
+| `ui.logo`                                       | URL to the logo to display.                                                                                                                     | `""`                       |
+| `ui.link`                                       | Link to open when the logo is clicked.                                                                                                          | `""`                       |
+| `ui.buttons`                                    | List of buttons to display below the header.                                                                                                    | `[]`                       |
+| `ui.buttons[].name`                             | Text to display on the button.                                                                                                                  | Required `""`              |
+| `ui.buttons[].link`                             | Link to open when the button is clicked.                                                                                                        | Required `""`              |
+| `maintenance`                                   | [Maintenance configuration](#maintenance).                                                                                                      | `{}`                       |
 
 
 ### Conditions
@@ -1528,6 +1530,28 @@ Placeholders `[STATUS]` and `[BODY]` as well as the fields `endpoints[].body`, `
 `endpoints[].method` and `endpoints[].graphql` are not supported for SCTP endpoints.
 
 This works for SCTP based application.
+
+### Monitoring a WebSocket endpoint
+By prefixing `endpoints[].url` with `ws://` or `wss://`, you can monitor WebSocket endpoints at a very basic level:
+
+```yaml
+endpoints:
+  - name: example
+    url: "wss://example.com/"
+    body: "status"
+    conditions:
+      - "[CONNECTED] == true"
+      - "[BODY].result >= 0"
+```
+
+The `[BODY]` placeholder contains the output of the query, and `[CONNECTED]`
+shows whether the connected was successfully established.
+
+Additionaly, the optional `jsonrpc` flag specifies whether to wrap the request
+body in a JSON RPC 2.0 method call, in which the first word becomes method name
+and the rest becomes parameters. For example, if the `body` is set to `status`
+and `jsonrpc` is set to `true`, Gatus will send the following as the WebSocket
+message: `{{"jsonrpc":"2.0","method":"status","params":[],"id":1}}`.
 
 ### Monitoring an endpoint using ICMP
 By prefixing `endpoints[].url` with `icmp:\\`, you can monitor endpoints at a very basic level using ICMP, or more

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -98,7 +98,7 @@ type Endpoint struct {
 	// GraphQL is whether to wrap the body in a query param ({"query":"$body"})
 	GraphQL bool `yaml:"graphql,omitempty"`
 
-	// JsonRPC is wether to wrap the body in as a JSON RPC 2.0 method call. First word becomes method name and the rest becomes parameters
+	// JsonRPC is whether to wrap the body in as a JSON RPC 2.0 method call. First word becomes method name and the rest becomes parameters
 	JsonRPC bool `yaml:"jsonrpc,omitempty"`
 
 	// Headers of the request

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -42,6 +42,7 @@ const (
 	EndpointTypeSTARTTLS EndpointType = "STARTTLS"
 	EndpointTypeTLS      EndpointType = "TLS"
 	EndpointTypeHTTP     EndpointType = "HTTP"
+	EndpointTypeWS       EndpointType = "WS"
 	EndpointTypeUNKNOWN  EndpointType = "UNKNOWN"
 )
 
@@ -97,6 +98,9 @@ type Endpoint struct {
 	// GraphQL is whether to wrap the body in a query param ({"query":"$body"})
 	GraphQL bool `yaml:"graphql,omitempty"`
 
+	// JsonRPC is wether to wrap the body in as a JSON RPC 2.0 method call. First word becomes method name and the rest becomes parameters
+	JsonRPC bool `yaml:"jsonrpc,omitempty"`
+
 	// Headers of the request
 	Headers map[string]string `yaml:"headers,omitempty"`
 
@@ -149,6 +153,8 @@ func (endpoint Endpoint) Type() EndpointType {
 		return EndpointTypeTLS
 	case strings.HasPrefix(endpoint.URL, "http://") || strings.HasPrefix(endpoint.URL, "https://"):
 		return EndpointTypeHTTP
+	case strings.HasPrefix(endpoint.URL, "ws://") || strings.HasPrefix(endpoint.URL, "wss://"):
+		return EndpointTypeWS
 	default:
 		return EndpointTypeUNKNOWN
 	}
@@ -188,6 +194,21 @@ func (endpoint *Endpoint) ValidateAndSetDefaults() error {
 	// and endpoint.GraphQL is set to true
 	if _, contentTypeHeaderExists := endpoint.Headers[ContentTypeHeader]; !contentTypeHeaderExists && endpoint.GraphQL {
 		endpoint.Headers[ContentTypeHeader] = "application/json"
+	}
+	// Wraps the body as JSON RPC 2.0 method
+	if endpoint.JsonRPC {
+		method_name := ""
+		method_parameters := ""
+
+		if len(endpoint.Body) > 0 {
+			slices := strings.Split(endpoint.Body, " ")
+			method_name = slices[0]
+
+			if len(slices) > 1 {
+				method_parameters = strings.Join(slices[1:], ",")
+			}
+		}
+		endpoint.Body = "{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"" + method_name + "\", \"parameters\": [" + method_parameters + "]}\n"
 	}
 	for _, endpointAlert := range endpoint.Alerts {
 		if err := endpointAlert.ValidateAndSetDefaults(); err != nil {
@@ -340,6 +361,9 @@ func (endpoint *Endpoint) call(result *Result) {
 		result.Duration = time.Since(startTime)
 	} else if endpointType == EndpointTypeICMP {
 		result.Connected, result.Duration = client.Ping(strings.TrimPrefix(endpoint.URL, "icmp://"), endpoint.ClientConfig)
+	} else if endpointType == EndpointTypeWS {
+		queryWebSocket(endpoint, result)
+		result.Duration = time.Since(startTime)
 	} else {
 		response, err = client.GetHTTPClient(endpoint.ClientConfig).Do(request)
 		result.Duration = time.Since(startTime)

--- a/core/websocket.go
+++ b/core/websocket.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"golang.org/x/net/websocket"
+)
+
+func queryWebSocket(endpoint *Endpoint, result *Result) {
+	origin := "http://localhost/"
+	url := endpoint.URL
+	message := endpoint.Body
+
+	config, err := websocket.NewConfig(url, origin)
+	if err != nil {
+		result.AddError("Error configuring WS connection:" + err.Error())
+		return
+	}
+
+	// Dial URL
+	ws, err := websocket.DialConfig(config)
+	if err != nil {
+		result.AddError("Error dialing WS:" + err.Error())
+		return
+	}
+	result.Connected = true
+
+	// Write message
+	if _, err := ws.Write([]byte(message)); err != nil {
+		//fmt.Println("Error writing:", err)
+		result.AddError("Erro writing WS message" + err.Error())
+		return
+	}
+
+	// Read message (1 kByte)
+	var msg = make([]byte, 1024)
+	var n int
+	if n, err = ws.Read(msg); err != nil {
+		result.AddError("Erro reading WS message" + err.Error())
+		return
+	}
+
+	result.Body = msg[:n]
+}

--- a/core/websocket.go
+++ b/core/websocket.go
@@ -5,11 +5,15 @@ import (
 )
 
 func queryWebSocket(endpoint *Endpoint, result *Result) {
-	origin := "http://localhost/"
+	const (
+		Origin             = "http://localhost/"
+		MaximumMessageSize = 1024 // in bytes
+	)
+		
 	url := endpoint.URL
 	message := endpoint.Body
 
-	config, err := websocket.NewConfig(url, origin)
+	config, err := websocket.NewConfig(url, Origin)
 	if err != nil {
 		result.AddError("Error configuring WS connection:" + err.Error())
 		return
@@ -29,8 +33,8 @@ func queryWebSocket(endpoint *Endpoint, result *Result) {
 		return
 	}
 
-	// Read message (1 kByte)
-	var msg = make([]byte, 1024)
+	// Read message
+	var msg = make([]byte, MaximumMessageSize)
 	var n int
 	if n, err = ws.Read(msg); err != nil {
 		result.AddError("Error reading WS message" + err.Error())
@@ -38,4 +42,7 @@ func queryWebSocket(endpoint *Endpoint, result *Result) {
 	}
 
 	result.Body = msg[:n]
+
+	// Close socket
+	defer ws.Close()
 }

--- a/core/websocket.go
+++ b/core/websocket.go
@@ -25,8 +25,7 @@ func queryWebSocket(endpoint *Endpoint, result *Result) {
 
 	// Write message
 	if _, err := ws.Write([]byte(message)); err != nil {
-		//fmt.Println("Error writing:", err)
-		result.AddError("Erro writing WS message" + err.Error())
+		result.AddError("Error writing WS message" + err.Error())
 		return
 	}
 
@@ -34,7 +33,7 @@ func queryWebSocket(endpoint *Endpoint, result *Result) {
 	var msg = make([]byte, 1024)
 	var n int
 	if n, err = ws.Read(msg); err != nil {
-		result.AddError("Erro reading WS message" + err.Error())
+		result.AddError("Error reading WS message" + err.Error())
 		return
 	}
 


### PR DESCRIPTION
WebSocket endpoints are automatically identified by the URL protocol specification: `wss://` or `ws://`. The request body is used as the "message" written to the server, and the answer is stored in the `[BODY]`.

Optionally, the user can set the `jsonrpc` flag to automatically wrap the request body in a JSON RPC 2.0 method call.