### PR TITLE
DO-1470 - Add RPC diff and remove absInt function

### DIFF
--- a/core/condition.go
+++ b/core/condition.go
@@ -401,14 +401,6 @@ func blockNum(result *Result, first, second string) bool {
 	return !(secondI-firstI > deltaThreshold)
 }
 
-// func absInt(number int64) int64 {
-// 	if number < 0 {
-// 		return -number
-// 	} else {
-// 		return number
-// 	}
-// }
-
 // isEqual compares two strings.
 //
 // Supports the "pat" and the "any" functions.

--- a/core/condition.go
+++ b/core/condition.go
@@ -398,7 +398,15 @@ func blockNum(result *Result, first, second string) bool {
 
 	}
 	result.AddError(fmt.Sprintf("rpc: %d, reference: %d, diff: %d", firstI, secondI, secondI-firstI))
-	return !(secondI-firstI > deltaThreshold)
+	return !(absInt(secondI-firstI) > deltaThreshold)
+}
+
+func absInt(number int64) int64 {
+	if number < 0 {
+		return -number
+	} else {
+		return number
+	}
 }
 
 // isEqual compares two strings.

--- a/core/condition.go
+++ b/core/condition.go
@@ -397,18 +397,17 @@ func blockNum(result *Result, first, second string) bool {
 		return false
 
 	}
-
-	result.AddError(fmt.Sprintf("rpc: %d, reference: %d", firstI, secondI))
-	return !(absInt(secondI-firstI) > deltaThreshold)
+	result.AddError(fmt.Sprintf("rpc: %d, reference: %d, diff: %d", firstI, secondI, secondI-firstI))
+	return !(secondI-firstI > deltaThreshold)
 }
 
-func absInt(number int64) int64 {
-	if number < 0 {
-		return -number
-	} else {
-		return number
-	}
-}
+// func absInt(number int64) int64 {
+// 	if number < 0 {
+// 		return -number
+// 	} else {
+// 		return number
+// 	}
+// }
 
 // isEqual compares two strings.
 //


### PR DESCRIPTION
add diff between rpc and reference and remove absInt function to reduce false alarms. This has already been tested and it works properly.

Gatos does not alert when the difference in value is negative:

<img width="1270" alt="Screen Shot 2023-07-24 at 15 17 46" src="https://github.com/lavanet/gatus/assets/99877151/abc80335-63b5-4806-977d-6166f8dd8186">
