### PR TITLE
core:websocket: close connection as early as possible

### DIFF
--- a/core/websocket.go
+++ b/core/websocket.go
@@ -25,6 +25,7 @@ func queryWebSocket(endpoint *Endpoint, result *Result) {
 		result.AddError("Error dialing WS:" + err.Error())
 		return
 	}
+	defer ws.Close()
 	result.Connected = true
 
 	// Write message
@@ -42,7 +43,4 @@ func queryWebSocket(endpoint *Endpoint, result *Result) {
 	}
 
 	result.Body = msg[:n]
-
-	// Close socket
-	defer ws.Close()
 }


### PR DESCRIPTION
The WS connection should be closed also when there are errors writing and reading the message.

Addresses #DO-1551