### PR TITLE
Fix parsing hexadecimal integers in conditions

### DIFF
--- a/core/condition.go
+++ b/core/condition.go
@@ -183,7 +183,7 @@ func (c Condition) hasIPPlaceholder() bool {
 
 func decodeHex(hex interface{}) (int64, error) {
 	hexStr := fmt.Sprintf("%v", hex)
-	value, err := strconv.ParseInt(hexStr[2:], 16, 64)
+	value, err := strconv.ParseInt(hexStr, 0, 64)
 	if err != nil {
 		return 0, err
 	}
@@ -205,9 +205,9 @@ type cosmosBlock struct {
 func ethBlockNum(result *Result, compareRpcs []string, first string) (int64, int64, bool) {
 	var firstI, secondI int64
 
-	firstI, err := decodeHex(first)
+	firstI, err := strconv.ParseInt(first, 0, 64)
 	if err != nil {
-		result.AddError(err.Error())
+		result.AddError("Error parsing input: " + err.Error())
 		return 0, 0, false
 	}
 
@@ -242,7 +242,7 @@ func ethBlockNum(result *Result, compareRpcs []string, first string) (int64, int
 
 func cosmosBlockNum(result *Result, compareRpcs []string, first string) (int64, int64, bool) {
 	var firstI, secondI int64
-	firstI, err := strconv.ParseInt(first, 10, 64)
+	firstI, err := strconv.ParseInt(first, 0, 64)
 	if err != nil {
 		result.AddError(err.Error())
 		return 0, 0, false
@@ -260,7 +260,7 @@ func cosmosBlockNum(result *Result, compareRpcs []string, first string) (int64, 
 			continue
 		}
 
-		secondI, err = strconv.ParseInt(res.Block.Header.Height, 10, 64)
+		secondI, err = strconv.ParseInt(res.Block.Header.Height, 0, 64)
 		if err != nil {
 			continue
 		}
@@ -544,7 +544,7 @@ func sanitizeAndResolveNumerical(list []string, result *Result) (parameters []st
 		if duration, err := time.ParseDuration(element); duration != 0 && err == nil {
 			// If the string is a duration, convert it to milliseconds
 			resolvedNumericalParameters = append(resolvedNumericalParameters, duration.Milliseconds())
-		} else if number, err := strconv.ParseInt(element, 10, 64); err != nil {
+		} else if number, err := strconv.ParseInt(element, 0, 64); err != nil {
 			// It's not an int, so we'll check if it's a float
 			if f, err := strconv.ParseFloat(element, 64); err == nil {
 				// It's a float, but we'll convert it to an int. We're losing precision here, but it's better than

--- a/core/condition_test.go
+++ b/core/condition_test.go
@@ -288,6 +288,27 @@ func TestCondition_evaluate(t *testing.T) {
 			ExpectedOutput:  "[BODY].data.id > 0",
 		},
 		{
+			Name:            "body-jsonpath-hexadecimal-int-using-greater-than",
+			Condition:       Condition("[BODY].data > 0"),
+			Result:          &Result{Body: []byte("{\"data\": \"0x1\"}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data > 0",
+		},
+		{
+			Name:            "body-jsonpath-octal-int-using-greater-than",
+			Condition:       Condition("[BODY].data > 0"),
+			Result:          &Result{Body: []byte("{\"data\": \"0o1\"}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data > 0",
+		},
+		{
+			Name:            "body-jsonpath-binary-int-using-greater-than",
+			Condition:       Condition("[BODY].data > 0"),
+			Result:          &Result{Body: []byte("{\"data\": \"0b1\"}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data > 0",
+		},
+		{
 			Name:            "body-jsonpath-complex-int-using-greater-than-failure",
 			Condition:       Condition("[BODY].data.id > 5"),
 			Result:          &Result{Body: []byte("{\"data\": {\"id\": 1}}")},


### PR DESCRIPTION
Remove the assumption that JSON contains only decimal integers and instead identify the base from the prefix of the data.

`strconv.ParseInt` can identify the base of the integer based on its "prefix":
- 0x -> hexadecimal
- 0o -> octal
- 0b -> binary
- decimal otherwise.